### PR TITLE
Add fly.io identifier and region to tick publish

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -217,7 +217,13 @@ func run(
 			case <-ctx.Done():
 				return
 			case t := <-ticker.C:
-				payload := fmt.Sprintf(`{"unix": %d}`, t.Unix())
+				// Get Fly.io environment variables
+				flyAppName := os.Getenv("FLY_APP_NAME")
+				flyRegion := os.Getenv("PRIMARY_REGION")
+				
+				// Create payload with Fly.io identifiers
+				payload := fmt.Sprintf(`{"unix": %d, "fly_app_name": "%s", "fly_region": "%s"}`, 
+					t.Unix(), flyAppName, flyRegion)
 				_ = nc.Publish("time.seconds", []byte(payload))
 			}
 		}


### PR DESCRIPTION
Add Fly.io app name and region to published tick data to provide origin identification.

---
<a href="https://cursor.com/background-agent?bcId=bc-daeec987-de29-4cb9-ad89-e30c8adfe498">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-daeec987-de29-4cb9-ad89-e30c8adfe498">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Time-based event payloads now include deployment context (application name and primary region) alongside the timestamp, enabling clearer identification and filtering across multi‑region environments.
  - When this context isn’t configured, the new fields are left blank without affecting delivery.
  - Publishing behavior is otherwise unchanged; only the payload is enriched, preserving compatibility with existing consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->